### PR TITLE
feat(jwk): per-issuer audience and subject pinning

### DIFF
--- a/jwk/audience_test.go
+++ b/jwk/audience_test.go
@@ -1,0 +1,158 @@
+// Copyright © 2026 The lutherauth authors
+
+package jwk
+
+import (
+	"testing"
+
+	jwtgo "github.com/golang-jwt/jwt/v4"
+)
+
+// Issuers used by the audience/subject tests. vercelISS models a Vercel OIDC
+// workload issuer (luthersystems/reliable#2175); legacyISS models the existing
+// lutherauth issuer that must remain unchecked for audience/subject.
+const (
+	vercelISS = "https://oidc.vercel.com/luther"
+	legacyISS = "luther:auth:ui-prod"
+
+	vercelAud = "https://vercel.com/luther"
+	vercelSub = "owner:luther:project:reliable:environment:production"
+)
+
+// audienceTestKeys builds JWKS for both issuers and a minting helper that signs
+// a token for an issuer with a given subject and audience set.
+func audienceTestKeys(t *testing.T) (Option, func(iss, sub string, aud ...string) string) {
+	t.Helper()
+	keysByIssuer := map[string]*issuerKeys{
+		vercelISS: makeIssuerJWKS(2),
+		legacyISS: makeIssuerJWKS(2),
+	}
+	serve := allIssuerOption(keysByIssuer, 0)
+	mint := func(iss, sub string, aud ...string) string {
+		claims := &TestClaims{}
+		claims.Issuer = iss
+		claims.Subject = sub
+		claims.Audience = jwtgo.ClaimStrings(aud)
+		ik := keysByIssuer[iss]
+		kid := randomKID(ik.pubKeys)
+		token, err := NewJWK(ik.prvKeys[kid], claims, kid)
+		if err != nil {
+			t.Fatalf("mint token: %s", err)
+		}
+		return token
+	}
+	return serve, mint
+}
+
+// TestWithExpectedAudienceAndSubject verifies per-issuer audience + subject
+// pinning: the Vercel issuer is constrained while the legacy issuer is left
+// unchecked (backwards-compatible).
+func TestWithExpectedAudienceAndSubject(t *testing.T) {
+	t.Parallel()
+
+	serve, mint := audienceTestKeys(t)
+	settings := NewSettings(
+		serve,
+		WithExpectedAudience(func(issuer string) []string {
+			if issuer == vercelISS {
+				return []string{vercelAud}
+			}
+			return nil // legacy issuer: audience not checked
+		}),
+		WithExpectedSubject(func(issuer string) []string {
+			if issuer == vercelISS {
+				return []string{vercelSub}
+			}
+			return nil // legacy issuer: subject not checked
+		}),
+	)
+
+	tests := []struct {
+		name    string
+		token   string
+		wantErr bool
+	}{
+		{
+			name:  "vercel matching aud+sub accepted",
+			token: mint(vercelISS, vercelSub, vercelAud),
+		},
+		{
+			name:  "vercel multi-aud containing expected accepted",
+			token: mint(vercelISS, vercelSub, "https://sts.amazonaws.com", vercelAud),
+		},
+		{
+			name:    "vercel wrong audience rejected",
+			token:   mint(vercelISS, vercelSub, "https://sts.amazonaws.com"),
+			wantErr: true,
+		},
+		{
+			name:    "vercel preview-environment subject rejected",
+			token:   mint(vercelISS, "owner:luther:project:reliable:environment:preview", vercelAud),
+			wantErr: true,
+		},
+		{
+			name:    "vercel missing audience rejected",
+			token:   mint(vercelISS, vercelSub),
+			wantErr: true,
+		},
+		{
+			name:  "legacy issuer aud+sub unchecked (backwards compatible)",
+			token: mint(legacyISS, "anything", "anything"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ValidateRS256(settings, &TestClaims{}, tc.token)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+// TestExpectedAudienceEmptyMeansUnchecked confirms that a configured function
+// returning an empty set leaves the audience unchecked (only a non-empty set
+// pins it), so enabling the option for one issuer never tightens another.
+func TestExpectedAudienceEmptyMeansUnchecked(t *testing.T) {
+	t.Parallel()
+
+	serve, mint := audienceTestKeys(t)
+	settings := NewSettings(
+		serve,
+		WithExpectedAudience(func(string) []string { return []string{} }),
+		WithExpectedSubject(func(string) []string { return nil }),
+	)
+
+	// Any audience is fine because the expected set is empty.
+	if _, err := ValidateRS256(settings, &TestClaims{}, mint(vercelISS, "whoever", "any-aud")); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// TestExpectedAudienceUnionsAcrossOptions confirms multiple WithExpectedAudience
+// options accumulate (union) for the same issuer.
+func TestExpectedAudienceUnionsAcrossOptions(t *testing.T) {
+	t.Parallel()
+
+	serve, mint := audienceTestKeys(t)
+	settings := NewSettings(
+		serve,
+		WithExpectedAudience(func(string) []string { return []string{"aud-a"} }),
+		WithExpectedAudience(func(string) []string { return []string{"aud-b"} }),
+	)
+
+	for _, aud := range []string{"aud-a", "aud-b"} {
+		if _, err := ValidateRS256(settings, &TestClaims{}, mint(vercelISS, "s", aud)); err != nil {
+			t.Fatalf("aud %q should be accepted via union: %s", aud, err)
+		}
+	}
+	if _, err := ValidateRS256(settings, &TestClaims{}, mint(vercelISS, "s", "aud-c")); err == nil {
+		t.Fatalf("aud-c should be rejected (not in union)")
+	}
+}

--- a/jwk/rs256.go
+++ b/jwk/rs256.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -241,8 +242,16 @@ type Settings struct {
 	cache               *keyCache
 	retrieveWebKeysFn   func(issuer string) (*gojwk.Key, error)
 	issuerToWebKeyURLFn func(issuer string) (string, error)
-	httpClient          *http.Client
-	getNow              func() time.Time // Allows us to mock the current time
+	// expectedAudienceFn returns the set of acceptable `aud` values for tokens
+	// from the given issuer. A nil function or an empty result means the
+	// audience is not checked for that issuer (backwards-compatible).
+	expectedAudienceFn func(issuer string) []string
+	// expectedSubjectFn returns the set of acceptable `sub` values for tokens
+	// from the given issuer. A nil function or an empty result means the
+	// subject is not checked for that issuer (backwards-compatible).
+	expectedSubjectFn func(issuer string) []string
+	httpClient        *http.Client
+	getNow            func() time.Time // Allows us to mock the current time
 }
 
 func (s *Settings) getKey(issuer string, kid string) *rsa.PublicKey {
@@ -397,6 +406,52 @@ func WithIssuerToWebKeyURL(issuerToWebKeyURLFn func(issuer string) (string, erro
 	}
 }
 
+// WithExpectedAudience restricts which `aud` (audience) values are accepted for
+// tokens from a given issuer. The supplied function receives the token issuer
+// and returns the set of acceptable audiences for it; an empty/nil result means
+// the audience is not checked for that issuer (backwards-compatible). Multiple
+// calls accumulate — the per-issuer sets are unioned — mirroring
+// WithIssuerToWebKeyURL's chaining. Enforced in ValidateRS256.
+func WithExpectedAudience(audienceForIssuer func(issuer string) []string) Option {
+	return func(s *Settings) {
+		oldFn := s.expectedAudienceFn
+		s.expectedAudienceFn = func(issuer string) []string {
+			var out []string
+			if oldFn != nil {
+				out = append(out, oldFn(issuer)...)
+			}
+			return append(out, audienceForIssuer(issuer)...)
+		}
+	}
+}
+
+// WithExpectedSubject restricts which `sub` (subject) values are accepted for
+// tokens from a given issuer, with the same semantics as WithExpectedAudience.
+// Useful to pin a federated workload identity (e.g. a specific Vercel
+// project/environment subject). Enforced in ValidateRS256.
+func WithExpectedSubject(subjectForIssuer func(issuer string) []string) Option {
+	return func(s *Settings) {
+		oldFn := s.expectedSubjectFn
+		s.expectedSubjectFn = func(issuer string) []string {
+			var out []string
+			if oldFn != nil {
+				out = append(out, oldFn(issuer)...)
+			}
+			return append(out, subjectForIssuer(issuer)...)
+		}
+	}
+}
+
+// audienceIntersects reports whether any element of have appears in want.
+func audienceIntersects(have jwtgo.ClaimStrings, want []string) bool {
+	for _, h := range have {
+		if slices.Contains(want, h) {
+			return true
+		}
+	}
+	return false
+}
+
 // WithHTTPClient allows specifying a custom http client used to retrieve
 // web keys.
 func WithHTTPClient(httpClient *http.Client) Option {
@@ -495,6 +550,23 @@ func ValidateRS256(settings *Settings, claims jwtgo.Claims, token string) (jwtgo
 			if !isAfterWithDrift(now, regClaims.NotBefore.Time) {
 				return nil, fmt.Errorf("jwt received too early (now) [%d] <= nbf [%d]", now.Unix(), regClaims.NotBefore.Time.Unix())
 			}
+		}
+	}
+
+	// Enforce per-issuer audience / subject allowlists when configured. These are
+	// checked on the parsed RegisteredClaims before signature verification, which
+	// is safe: the signature check below still gates every successful return, so a
+	// forged token cannot pass it. Issuers with no configured allowlist are not
+	// checked, keeping the legacy (lutherauth) path unchanged. Added for Vercel
+	// OIDC federation (luthersystems/reliable#2175).
+	if settings.expectedAudienceFn != nil {
+		if want := settings.expectedAudienceFn(issuer); len(want) > 0 && !audienceIntersects(regClaims.Audience, want) {
+			return nil, fmt.Errorf("audience not accepted for issuer %q", issuer)
+		}
+	}
+	if settings.expectedSubjectFn != nil {
+		if want := settings.expectedSubjectFn(issuer); len(want) > 0 && !slices.Contains(want, regClaims.Subject) {
+			return nil, fmt.Errorf("subject not accepted for issuer %q", issuer)
 		}
 	}
 


### PR DESCRIPTION
## What

Adds two `jwk` options, enforced centrally in `ValidateRS256`:

- `WithExpectedAudience(func(issuer) []string)` — pins accepted `aud` values per issuer
- `WithExpectedSubject(func(issuer) []string)` — pins accepted `sub` values per issuer

Issuers with no configured allowlist are left unchecked, so existing single-issuer (lutherauth) verification is unchanged. The checks run on the parsed claims before signature verification, which still gates every successful return — a forged token can't satisfy them.

## Why

Enables `ui-core` to accept Vercel OIDC workload tokens as a second trusted issuer (with audience + subject pinning) alongside the legacy lutherauth JWT, without an `svc` change. See luthersystems/reliable#2175.

## Test plan

- `go test ./jwk/...` — new accept/reject/union/backward-compat cases plus the full suite, green.

## Release note

Tag as `v0.0.8` after merge. ui-core currently points at this branch's pseudo-version and should bump to the tag once it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BuLLgmFLACzskqWHVbwVo

---
_Generated by [Claude Code](https://claude.ai/code/session_013BuLLgmFLACzskqWHVbwVo)_