### PR TITLE
ci: move govulncheck shell out of workflow YAML into scripts/

### DIFF
--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -33,13 +33,12 @@ jobs:
           go-version: "stable"
           cache: true
 
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
       - name: Run govulncheck
         id: scan
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          set +e
-          govulncheck ./... 2>&1 | tee /tmp/govulncheck.txt
-          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+        run: bash scripts/govulncheck-scan.sh
 
       # Second, ADDITIVE pass over the built binaries. NOT a substitute for the
       # source scan above and must not become one: source mode reports
@@ -56,27 +55,7 @@ jobs:
       # Library modules have no main packages; there the step is a no-op.
       - name: Run govulncheck (binary mode)
         id: binscan
-        run: |
-          set -o pipefail
-          status=0
-          mains=$(go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./... | grep -v '^$' || true)
-          if [ -z "$mains" ]; then
-            echo "No main packages in this module — binary mode does not apply."
-            echo "exit=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          mkdir -p /tmp/gv-bins
-          for pkg in $mains; do
-            out="/tmp/gv-bins/$(echo "$pkg" | tr '/' '_')"
-            go build -o "$out" "$pkg"
-            echo "::group::govulncheck -mode=binary ${pkg}"
-            if ! govulncheck -mode=binary "$out" 2>&1 | tee -a /tmp/govulncheck.txt; then
-              status=1
-            fi
-            echo "::endgroup::"
-            rm -f "$out"
-          done
-          echo "exit=${status}" >> "$GITHUB_OUTPUT"
+        run: bash scripts/govulncheck-binary-scan.sh
 
       - name: Open, refresh or close the tracking issue
         uses: actions/github-script@v7

--- a/scripts/govulncheck-binary-scan.sh
+++ b/scripts/govulncheck-binary-scan.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Binary-mode govulncheck pass for the scheduled workflow.
+#
+# Extracted from .github/workflows/govulncheck-scheduled.yml. Run locally as:
+#
+#   GITHUB_OUTPUT=/dev/stdout scripts/govulncheck-binary-scan.sh
+#
+# ADDITIVE to the source scan, never a replacement: source mode reports
+# vulnerabilities in imported packages even when the linker dropped the code,
+# which binary mode cannot see. What binary mode adds is reflection-reached code
+# (the govulncheck docs state such calls are not reported in source scan mode)
+# and the standard library at the version the binary was BUILT with rather than
+# the version the scanner runs under.
+#
+# Library modules have no main packages; there this is a no-op, not an error.
+set -uo pipefail
+
+REPORT_PATH="${REPORT_PATH:-/tmp/govulncheck.txt}"
+BIN_DIR="${BIN_DIR:-/tmp/gv-bins}"
+
+mains="$(go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./... | grep -v '^$' || true)"
+if [ -z "$mains" ]; then
+  echo "No main packages in this module — binary mode does not apply."
+  echo "exit=0" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+mkdir -p "$BIN_DIR"
+status=0
+for pkg in $mains; do
+  out="${BIN_DIR}/$(echo "$pkg" | tr '/' '_')"
+  go build -o "$out" "$pkg"
+  echo "::group::govulncheck -mode=binary ${pkg}"
+  # pipefail so the pipeline reports govulncheck's status rather than tee's;
+  # `if !` so a finding does not abort the loop before later binaries are scanned.
+  if ! govulncheck -mode=binary "$out" 2>&1 | tee -a "$REPORT_PATH"; then
+    status=1
+  fi
+  echo "::endgroup::"
+  rm -f "$out"
+done
+
+echo "exit=${status}" >> "${GITHUB_OUTPUT:-/dev/null}"
+exit 0

--- a/scripts/govulncheck-scan.sh
+++ b/scripts/govulncheck-scan.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Source-mode govulncheck scan for the scheduled workflow.
+#
+# Extracted from .github/workflows/govulncheck-scheduled.yml so the logic lives
+# in a real, lintable, runnable file and the workflow step stays a thin shim.
+# Run it locally exactly as CI does:
+#
+#   GITHUB_OUTPUT=/dev/stdout scripts/govulncheck-scan.sh
+#
+# Writes the full report to $REPORT_PATH for the drift-issue body, and the scan's
+# exit status to $GITHUB_OUTPUT as `exit=N`. It deliberately does NOT fail the
+# step itself -- the workflow decides, after the binary pass has also run, so a
+# finding in one mode cannot mask the other.
+set -uo pipefail
+
+REPORT_PATH="${REPORT_PATH:-/tmp/govulncheck.txt}"
+
+# `set +e` around the pipeline, then read PIPESTATUS immediately: the pipeline's
+# own status is tee's, which succeeds regardless, so reading it would silently
+# swallow every finding.
+set +e
+govulncheck ./... 2>&1 | tee "$REPORT_PATH"
+status="${PIPESTATUS[0]}"
+set -e
+
+echo "exit=${status}" >> "${GITHUB_OUTPUT:-/dev/null}"
+exit 0


### PR DESCRIPTION
Embedded shell in a workflow can't be linted, can't be run locally, and can't be tested. This moves it into real scripts, leaving each workflow step a one-line shim.

| Script | What |
|---|---|
| `scripts/govulncheck-scan.sh` | source-mode scan |
| `scripts/govulncheck-binary-scan.sh` | additive binary-mode pass |

Same convention already used for `scripts/govulncheck-drift.cjs` on the JS half.

## Behaviour is unchanged — and now actually verified

The point of extraction is that these became testable. Each was exercised standalone with a stubbed `govulncheck` on `PATH`:

```
finding case  -> captured: exit=3   report written
clean case    -> captured: exit=0
no main pkgs  -> "binary mode does not apply", exit=0
```

That last case is the one that matters **here**: this is a library module with zero main packages, so the binary pass takes the no-op path on every run. It must skip cleanly rather than error, and that's now covered by an actual run rather than an assumption.

The exit-capture shape is the other reason to have this in a testable file. The naive form reports `tee`'s exit status, which always succeeds — every finding would be silently swallowed and the gate would pass forever.

## Also restored a step I'd dropped

The workflow previously ran `go install govulncheck` *inside* the scan step. Extracting the block removed it, so the scripts would have run against a missing binary. It's back as its own explicit step — caught by grepping for it after the refactor, not by CI, since this workflow has no `pull_request` trigger.

## Test plan

- All scripts pass `bash -n`; workflow YAML parses.
- Verified no multi-line `run:` blocks remain.
- Stub-driven runs as above, including the library no-op path this repo actually takes.
- This workflow only triggers on `schedule` / `workflow_dispatch`, so CI does not exercise it here — fire one with `workflow_dispatch` after merge to confirm end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_