### PR TITLE
ci: tell govulncheck build failures apart from vulnerability findings

### DIFF
--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -53,20 +53,52 @@ jobs:
       # the version the scanner runs under.
       #
       # Library modules have no main packages; there the step is a no-op.
+      #
+      # This pass has to `go build` each main package before it has anything to
+      # scan, so it goes red for two unrelated reasons: a compile error, or an
+      # actual finding. Both still FAIL -- a package that did not compile was
+      # not scanned, and an unscanned package is not a clean one -- but the
+      # script now reports them as separate outputs (`build_failed` /
+      # `vulns_found`) and emits a distinct `::error::` for each, so the check
+      # name "govulncheck" stops turning a build break into a phantom security
+      # finding (ui-core run 31232762542: red, zero vulnerabilities, and the
+      # real cause was argo-workflows v4.0.8 not compiling against a bumped
+      # k8s.io/api).
+      #
+      # The script exits NON-ZERO on either condition, which is why the two
+      # steps below carry `!cancelled()` guards -- without them a failure here
+      # would skip the tracking-issue writer.
       - name: Run govulncheck (binary mode)
         id: binscan
         run: bash scripts/govulncheck-binary-scan.sh
 
+      # `!cancelled()` + the outcome guard keeps this reachable now that the
+      # binary pass can exit non-zero, while preserving the old behaviour that a
+      # setup failure (checkout / install) skips the writer entirely -- a
+      # skipped scan must never be read as "clean" and auto-close the issue.
       - name: Open, refresh or close the tracking issue
+        if: ${{ !cancelled() && steps.binscan.outcome != 'skipped' }}
         uses: actions/github-script@v7
         env:
           FOUND: ${{ steps.scan.outputs.exit != '0' || steps.binscan.outputs.exit != '0' }}
+          # Split out so the issue does not describe a compile error as a
+          # "reachable vulnerability" and send its reader hunting a CVE that
+          # does not exist.
+          VULN_FOUND: ${{ steps.scan.outputs.exit != '0' || steps.binscan.outputs.vulns_found == '1' }}
+          BUILD_FAILED: ${{ steps.binscan.outputs.build_failed == '1' }}
           REPORT_PATH: /tmp/govulncheck.txt
         with:
           script: |
             const run = require('./scripts/govulncheck-drift.cjs');
             await run({ github, context, core });
 
-      - name: Fail if vulnerabilities were found
-        if: steps.scan.outputs.exit != '0' || steps.binscan.outputs.exit != '0'
-        run: exit 1
+      # Named for what it actually gates: a finding OR a build break. The
+      # script only reports which condition tripped (log + job summary) and
+      # then fails; it never decides whether to fail.
+      - name: Fail if govulncheck reported a finding or a build break
+        if: ${{ !cancelled() && (steps.scan.outputs.exit != '0' || steps.binscan.outputs.exit != '0') }}
+        env:
+          SOURCE_SCAN_EXIT: ${{ steps.scan.outputs.exit }}
+          BINARY_BUILD_FAILED: ${{ steps.binscan.outputs.build_failed }}
+          BINARY_VULNS_FOUND: ${{ steps.binscan.outputs.vulns_found }}
+        run: bash scripts/govulncheck-fail-summary.sh

--- a/scripts/govulncheck-binary-scan.sh
+++ b/scripts/govulncheck-binary-scan.sh
@@ -13,32 +13,155 @@
 # the version the scanner runs under.
 #
 # Library modules have no main packages; there this is a no-op, not an error.
+#
+# ---------------------------------------------------------------------------
+# BUILD FAILURE vs VULNERABILITY FINDING
+# ---------------------------------------------------------------------------
+# This pass has to `go build` every main package before it has an artifact to
+# scan, so there are two independent ways for it to go red and they call for
+# completely different responses:
+#
+#   build_failed=1   the tree did not compile. NOT a security finding.
+#   vulns_found=1    the binary built, and govulncheck reported against it.
+#
+# BOTH still fail, and that is deliberate: a package that does not compile has
+# not been scanned, so calling it clean would open a hole in the gate. What
+# changes here is only diagnosability -- each condition gets its own loud
+# ::error::, its own line in the job summary, and its own step output, so a
+# reader (and scripts/govulncheck-drift.cjs, which files the tracking issue)
+# can tell them apart.
+#
+# The triggering example: ui-core run 31232762542 was red under the check name
+# "govulncheck" with ZERO vulnerabilities in every tree -- argo-workflows
+# v4.0.8 had stopped compiling against a bumped k8s.io/api. Every reader of
+# that check concluded "security finding" and was wrong.
+#
+# `set -o pipefail` below is load-bearing and really is set (it is the `o` in
+# `set -uo pipefail`): without it the `govulncheck | tee` pipeline would report
+# tee's status, which always succeeds, and every finding would be swallowed.
+# Statuses are captured with `|| status=$?` on the command/pipeline itself,
+# never via ${PIPESTATUS[0]} -- PIPESTATUS is clobbered by ANY subsequent
+# command, including `|| true`, and reading it late silently passes the gate.
 set -uo pipefail
 
 REPORT_PATH="${REPORT_PATH:-/tmp/govulncheck.txt}"
 BIN_DIR="${BIN_DIR:-/tmp/gv-bins}"
+OUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
-mains="$(go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./... | grep -v '^$' || true)"
+# emit_outputs <build_failed> <vulns_found>
+#
+# `exit` is the pre-existing aggregate output the workflows already gate on;
+# build_failed / vulns_found are the new, separately-readable conditions.
+emit_outputs() {
+  local aggregate=0
+  if [ "$1" != "0" ] || [ "$2" != "0" ]; then
+    aggregate=1
+  fi
+  {
+    echo "build_failed=$1"
+    echo "vulns_found=$2"
+    echo "exit=${aggregate}"
+  } >>"$OUT_FILE"
+}
+
+# `go list` failing is itself a build-level failure (a syntax error anywhere in
+# the module makes it non-zero), and its stdout is empty in that case -- so it
+# must NOT be mistaken for "this module has no main packages".
+if ! mains_raw="$(go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./...)"; then
+  echo "::error title=govulncheck binary pass: BUILD FAILURE (not a vulnerability)::\`go list ./...\` failed, so no package could be built or scanned. This is a build/module error, NOT a govulncheck finding."
+  {
+    echo "=== BUILD FAILURE: go list ./... failed ==="
+    echo "No package could be enumerated, so binary-mode govulncheck scanned"
+    echo "nothing. This is a build error, NOT a vulnerability finding."
+  } >>"$REPORT_PATH"
+  {
+    echo "### govulncheck binary pass: BUILD FAILURE (not a vulnerability)"
+    echo
+    echo '`go list ./...` failed — nothing was built, nothing was scanned.'
+  } >>"$SUMMARY_FILE"
+  emit_outputs 1 0
+  exit 1
+fi
+
+mains="$(printf '%s\n' "$mains_raw" | grep -v '^$' || true)"
 if [ -z "$mains" ]; then
   echo "No main packages in this module — binary mode does not apply."
-  echo "exit=0" >> "${GITHUB_OUTPUT:-/dev/null}"
+  emit_outputs 0 0
   exit 0
 fi
 
 mkdir -p "$BIN_DIR"
-status=0
+build_failed=0
+vulns_found=0
+failed_builds=""
+found_pkgs=""
+
 for pkg in $mains; do
   out="${BIN_DIR}/$(echo "$pkg" | tr '/' '_')"
-  go build -o "$out" "$pkg"
-  echo "::group::govulncheck -mode=binary ${pkg}"
-  # pipefail so the pipeline reports govulncheck's status rather than tee's;
-  # `if !` so a finding does not abort the loop before later binaries are scanned.
-  if ! govulncheck -mode=binary "$out" 2>&1 | tee -a "$REPORT_PATH"; then
-    status=1
+
+  echo "::group::go build ${pkg}"
+  build_status=0
+  go build -o "$out" "$pkg" || build_status=$?
+  echo "::endgroup::"
+
+  if [ "$build_status" -ne 0 ]; then
+    build_failed=1
+    failed_builds="${failed_builds}${failed_builds:+ }${pkg}"
+    rm -f "$out"
+    echo "::error title=govulncheck binary pass: BUILD FAILURE (not a vulnerability)::\`go build ${pkg}\` exited ${build_status}. This is a COMPILE ERROR in the tree, NOT a govulncheck finding — the package was not scanned at all. Fix the build, then re-read the scan."
+    {
+      echo "=== BUILD FAILURE: ${pkg} (go build exit ${build_status}) ==="
+      echo "This package could not be compiled, so binary-mode govulncheck did"
+      echo "not scan it. This is a build error, NOT a vulnerability finding."
+    } >>"$REPORT_PATH"
+    continue
   fi
+
+  echo "::group::govulncheck -mode=binary ${pkg}"
+  gv_status=0
+  govulncheck -mode=binary "$out" 2>&1 | tee -a "$REPORT_PATH" || gv_status=$?
   echo "::endgroup::"
   rm -f "$out"
+
+  if [ "$gv_status" -ne 0 ]; then
+    vulns_found=1
+    found_pkgs="${found_pkgs}${found_pkgs:+ }${pkg}"
+    if [ "$gv_status" -eq 3 ]; then
+      # 3 is govulncheck's documented "vulnerabilities found" exit code.
+      echo "::error title=govulncheck binary pass: vulnerability found::govulncheck -mode=binary reported a finding in the built binary for ${pkg}. The binary compiled fine — this IS a security finding."
+    else
+      echo "::error title=govulncheck binary pass: scanner failure::govulncheck -mode=binary exited ${gv_status} for ${pkg}. The binary compiled fine, but ${gv_status} is not govulncheck's vulnerabilities-found code (3), so this is more likely a scanner error than a finding. Failing either way — an unscanned binary is not a clean binary."
+    fi
+  fi
 done
 
-echo "exit=${status}" >> "${GITHUB_OUTPUT:-/dev/null}"
+{
+  if [ "$build_failed" -ne 0 ]; then
+    echo "### govulncheck binary pass: BUILD FAILURE (not a vulnerability)"
+    echo
+    echo "These \`main\` packages did not compile, so they were **not scanned**:"
+    echo
+    for p in $failed_builds; do
+      echo "- \`${p}\`"
+    done
+    echo
+    echo "Fix the compile error. Do not read this as a security finding."
+    echo
+  fi
+  if [ "$vulns_found" -ne 0 ]; then
+    echo "### govulncheck binary pass: findings in built binaries"
+    echo
+    for p in $found_pkgs; do
+      echo "- \`${p}\`"
+    done
+    echo
+  fi
+} >>"$SUMMARY_FILE"
+
+emit_outputs "$build_failed" "$vulns_found"
+
+if [ "$build_failed" -ne 0 ] || [ "$vulns_found" -ne 0 ]; then
+  exit 1
+fi
 exit 0

--- a/scripts/govulncheck-drift.cjs
+++ b/scripts/govulncheck-drift.cjs
@@ -11,8 +11,19 @@
 //       await run({ github, context, core });
 //
 // Inputs (env):
-//   FOUND        'true' when the scan reported a reachable vulnerability
-//   REPORT_PATH  path to the captured govulncheck output (default /tmp/govulncheck.txt)
+//   FOUND         'true' when ANY condition tripped (vulnerability or build break)
+//   VULN_FOUND    'true' when a scan actually reported a vulnerability
+//   BUILD_FAILED  'true' when the binary-mode pass could not BUILD a main package
+//   REPORT_PATH   path to the captured govulncheck output (default /tmp/govulncheck.txt)
+//
+// VULN_FOUND / BUILD_FAILED exist because the binary-mode pass has to compile
+// every main package before it can scan it, so it goes red for two unrelated
+// reasons. Filing "reachable vulnerability on main" for a compile error sends
+// whoever picks up the issue hunting a CVE that does not exist (the triggering
+// case: ui-core run 31232762542, red with zero vulnerabilities because
+// argo-workflows v4.0.8 stopped compiling against a bumped k8s.io/api). Both
+// still open an issue -- an unscanned tree is not a clean tree -- but the
+// issue says which one happened.
 //
 // Behaviour:
 //   - finding + no open issue   -> open one, labelled `govulncheck-drift`
@@ -25,12 +36,20 @@
 // rather than a version bump, so there is nothing safe to auto-apply.
 
 const LABEL = 'govulncheck-drift';
-const TITLE = 'govulncheck: reachable vulnerability on main';
+const TITLE_VULN = 'govulncheck: reachable vulnerability on main';
+const TITLE_BUILD = 'govulncheck: binary-mode build failure on main';
 const MAX_REPORT_BYTES = 50000;
 
 module.exports = async ({ github, context, core }) => {
   const fs = require('fs');
   const found = process.env.FOUND === 'true';
+  const buildFailed = process.env.BUILD_FAILED === 'true';
+  // Fall back to the old single-flag behaviour when a caller has not been
+  // updated to pass VULN_FOUND: anything that is not a known build break is
+  // reported as a vulnerability, exactly as before.
+  const vulnFound = process.env.VULN_FOUND
+    ? process.env.VULN_FOUND === 'true'
+    : found && !buildFailed;
   const reportPath = process.env.REPORT_PATH || '/tmp/govulncheck.txt';
   const { owner, repo } = context.repo;
   const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
@@ -72,12 +91,34 @@ module.exports = async ({ github, context, core }) => {
     core.warning(`Could not read ${reportPath}: ${err.message}`);
   }
 
+  const lead = [];
+  if (buildFailed) {
+    lead.push(
+      'The scheduled `govulncheck` run went red because the binary-mode pass',
+      '**could not build** one or more `main` packages.',
+      '',
+      '**This is a build break, not a vulnerability finding.** The packages that',
+      'failed to compile were not scanned at all, which is why the run still',
+      'fails -- an unscanned tree is not a clean tree. Fix the compile error',
+      'first; look for the `BUILD FAILURE` lines in the report below.',
+      '',
+    );
+  }
+  if (vulnFound) {
+    lead.push(
+      'Scheduled `govulncheck` found a reachable vulnerability on `main`.',
+      '',
+      'This is a **reachability** finding: govulncheck only reports when this',
+      'module actually calls the vulnerable code, so it is not import-only noise.',
+      '',
+    );
+  }
+  if (lead.length === 0) {
+    lead.push('Scheduled `govulncheck` reported a failure on `main`.', '');
+  }
+
   const body = [
-    'Scheduled `govulncheck` found a reachable vulnerability on `main`.',
-    '',
-    'This is a **reachability** finding: govulncheck only reports when this',
-    'module actually calls the vulnerable code, so it is not import-only noise.',
-    '',
+    ...lead,
     `Run: ${runUrl}`,
     '',
     '<details><summary>Report</summary>',
@@ -103,7 +144,7 @@ module.exports = async ({ github, context, core }) => {
   const created = await github.rest.issues.create({
     owner,
     repo,
-    title: TITLE,
+    title: buildFailed && !vulnFound ? TITLE_BUILD : TITLE_VULN,
     body,
     labels: [LABEL],
   });

--- a/scripts/govulncheck-fail-summary.sh
+++ b/scripts/govulncheck-fail-summary.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Final gate step for the govulncheck workflows.
+#
+# The job goes red for more than one reason and the check name ("govulncheck")
+# reads as "security finding" for all of them. This step exists so the LAST
+# thing in the log, and the top of the job summary, names which condition
+# actually tripped. It never decides anything and never softens anything: it
+# fails whenever any condition is set.
+#
+# Inputs (env, all optional — an unset/empty value counts as "did not trip"):
+#   SOURCE_SCAN_EXIT      steps.scan.outputs.exit      (source-mode pass)
+#   BINARY_BUILD_FAILED   steps.binscan.outputs.build_failed
+#   BINARY_VULNS_FOUND    steps.binscan.outputs.vulns_found
+#
+# Run locally as:
+#   BINARY_BUILD_FAILED=1 scripts/govulncheck-fail-summary.sh
+set -uo pipefail
+
+SOURCE_SCAN_EXIT="${SOURCE_SCAN_EXIT:-0}"
+BINARY_BUILD_FAILED="${BINARY_BUILD_FAILED:-0}"
+BINARY_VULNS_FOUND="${BINARY_VULNS_FOUND:-0}"
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+reasons=()
+if [ "$SOURCE_SCAN_EXIT" != "0" ] && [ -n "$SOURCE_SCAN_EXIT" ]; then
+  reasons+=("VULNERABILITY: the source-mode scan reported a finding.")
+fi
+if [ "$BINARY_BUILD_FAILED" != "0" ] && [ -n "$BINARY_BUILD_FAILED" ]; then
+  reasons+=("BUILD FAILURE: a main package did not compile, so the binary-mode pass could not scan it. This is NOT a vulnerability finding.")
+fi
+if [ "$BINARY_VULNS_FOUND" != "0" ] && [ -n "$BINARY_VULNS_FOUND" ]; then
+  reasons+=("VULNERABILITY: the binary-mode pass reported a finding against a binary that built fine.")
+fi
+
+if [ "${#reasons[@]}" -eq 0 ]; then
+  echo "No govulncheck condition tripped — nothing to fail."
+  exit 0
+fi
+
+{
+  echo "## govulncheck failed"
+  echo
+  for r in "${reasons[@]}"; do
+    echo "- ${r}"
+  done
+  echo
+} >>"$SUMMARY_FILE"
+
+echo "govulncheck failed for the following reason(s):"
+for r in "${reasons[@]}"; do
+  echo "  - ${r}"
+done
+
+exit 1


### PR DESCRIPTION
## Problem

The binary-mode govulncheck pass has to `go build` every `main` package before it has an artifact to scan. So the check named **govulncheck** goes red for two unrelated reasons, and today they are indistinguishable in the log and in the check name.

Real case: ui-core run 31232762542 was red with **zero** vulnerabilities in every tree — argo-workflows v4.0.8 had stopped compiling against a bumped `k8s.io/api`. Anyone reading the check name concluded "reachable vulnerability" and was wrong.

## What this does NOT do

The gate is not relaxed. A build failure still fails, because a package that did not compile was not scanned, and an unscanned package is not a clean one.

- no `continue-on-error`
- no `|| true` on the build
- no skipping the binary pass when the build breaks
- no condition removed from any gate

Only diagnosability changes. (This module has no `main` packages today, so the binary pass is a no-op here — the fix lands for consistency and for the day it grows one.)

## Changes

- `scripts/govulncheck-binary-scan.sh` captures the `go build` status separately from the `govulncheck` status and reports them as separate step outputs — `build_failed` and `vulns_found` — alongside the pre-existing aggregate `exit` the workflow already gates on. Each condition emits its own loud `::error::` and its own job-summary section. A build break no longer aborts the loop, so one run reports every package. The script now exits non-zero when either condition trips.
- A non-zero `govulncheck` status that is not `3` (its documented vulnerabilities-found code) is labelled a scanner failure rather than a finding. It still fails.
- `scripts/govulncheck-fail-summary.sh` (new) is the final gate step: it names which condition tripped, in the log and the job summary, then fails. It only reports — it never decides whether to fail. The workflow step stays a one-line shim with env inputs.
- `scripts/govulncheck-drift.cjs` takes `BUILD_FAILED` / `VULN_FOUND` so the daily tracking issue does not file a compile error as "reachable vulnerability" and send its reader hunting a CVE that does not exist. Callers that pass neither keep the previous wording and title.
- Because the binary pass can now exit non-zero, the tracking-issue step and the final gate step carry `!cancelled()` guards, plus `steps.binscan.outcome != 'skipped'` on the issue writer. That reproduces the old reachability exactly: the writer still runs whenever the scans ran, and is still skipped when checkout/install failed — so a setup failure can never be read as "clean" and auto-close the issue.

## Correctness notes

Both traps that have bitten this codebase before are handled explicitly:

- `pipefail` really is set (`set -uo pipefail`), so the `govulncheck | tee` pipeline reports govulncheck's status and not tee's. The comment claiming it and the `set` line agree.
- Every status is captured with `|| status=$?` on the command or pipeline itself, never via `${PIPESTATUS[0]}` — PIPESTATUS is clobbered by any subsequent command, including `|| true`, and reading it late silently passes the gate.

## Verification

Tested standalone with a stubbed `go` / `govulncheck` on PATH, and again against the real Go toolchain on a scratch module and on a real repo checkout. Captured exit status of `scripts/govulncheck-binary-scan.sh`:

| case | exit | build_failed | vulns_found |
|---|---|---|---|
| (a) `go build` fails | 1 | 1 | 0 |
| (b) build OK, govulncheck reports a finding (exit 3) | 1 | 0 | 1 |
| (c) build OK, govulncheck clean | 0 | 0 | 0 |
| (d) module has no `main` packages | 0 | 0 | 0 |
| (e) mixed: one broken build + one vulnerable binary | 1 | 1 | 1 |
| (f) govulncheck exits non-zero but not 3 (scanner error) | 1 | 0 | 1 |

Case (b) is also the pipefail regression proof: govulncheck exits 3 through `| tee` and the script still returns 1. Case (d) is the path this repo takes today, verified against a real library-only module.

`scripts/govulncheck-fail-summary.sh` was exercised for build-only, vuln-only, all-three, and nothing-tripped (exit 0) inputs. `scripts/govulncheck-drift.cjs` was exercised against a fake octokit for build-failure-only (build-failure title and body), vulnerability-only, both, a legacy caller passing only `FOUND`, and the clean/auto-close path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_