### PR TITLE
ci: pin Go to 1.26.x — "stable" flipped to 1.27 and broke lint

### DIFF
--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "stable"
+          go-version: "1.26.x"
           cache: true
 
       - name: Install govulncheck

--- a/.github/workflows/lutherauth-sdk-go.yml
+++ b/.github/workflows/lutherauth-sdk-go.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "stable"
+          go-version: "1.26.x"
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "stable"
+          go-version: "1.26.x"
       - name: Run tests
         run: go test -v ./...
   # Known-vulnerability gate: call-graph-aware, fails only on vulns whose
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "stable"
+          go-version: "1.26.x"
       - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/jwk/rs256.go
+++ b/jwk/rs256.go
@@ -270,9 +270,9 @@ func (s *Settings) putKey(issuer string, kid string, key *rsa.PublicKey) {
 
 func newHTTPClient() *http.Client {
 	var netTransport = &http.Transport{
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout: 5 * time.Second,
-		}).Dial,
+		}).DialContext,
 		TLSHandshakeTimeout: 5 * time.Second,
 		Proxy:               http.ProxyFromEnvironment,
 	}


### PR DESCRIPTION
## Why

The `lint` job broke on 2026-08-20 with **no code change**: `setup-go`'s `go-version: "stable"` flipped to **go1.27.0**, and the pinned golangci-lint v2.11 is built with go1.26 — it panics on any code under a go1.27 toolchain:

```
panic: file requires newer Go version go1.27 (application built with go1.26)
```

Dating evidence: #29's lint passed Aug 13, #30's failed Aug 20, on equivalent content. Main fails identically — the Dependabot PRs were never at fault.

## Fix (per maintainer direction: we're not on Go 1.27 yet)

Pin all three jobs (`lint`, `test`, `govulncheck`) to `go-version: "1.26.x"` so CI runs the Go the org actually builds with, instead of whatever GitHub promotes to "stable". The golangci-lint pin stays at v2.11, which works fine under a 1.26 toolchain.

> An earlier revision of this PR instead bumped golangci-lint to v2.13 (go1.27-built) to tolerate the new toolchain; reworked to the pin after maintainer direction that the org isn't moving to 1.27 yet.

## Also included

`jwk/rs256.go`: deprecated `http.Transport.Dial` → `DialContext` (SA1019, surfaced while diagnosing; behavior-equivalent, no suppressions). Happy to drop this into its own PR if you'd rather keep this CI-only.

## Verification

- Root cause taken from the actual CI log archive (run 32384773041), not inferred
- On this branch: `go build ./...`, `go vet ./...`, `go test ./...` all pass; golangci-lint clean at 0 issues (verified under two linter builds)
- No `go.mod`/`go.sum` changes; nothing merged, Dependabot branch #30 untouched

Once merged, re-running #30's checks (or a Dependabot rebase) should turn it green — everything except lint already passed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)